### PR TITLE
Layout startpagina aanpassingen

### DIFF
--- a/src/app/(www)/page.tsx
+++ b/src/app/(www)/page.tsx
@@ -11,7 +11,7 @@ export default function Index() {
                     geboortereceptie, verjaardagsfeest, vergaderingen en communiefeest worden gereserveerd.</p>
             </div>
             <div className={"h-full aspect-video md:aspect-auto relative"}>
-                <Image className={"object-cover rounded"} src={"/images/tenboomgaerde.jpg"} alt={"Foto van het gebouw"} fill/>
+                <Image priority className={"object-cover rounded"} src={"/images/tenboomgaerde.jpg"} alt={"Foto van het gebouw"} fill/>
             </div>
             <aside className={"lg:col-start-2 xl:col-start-3 flex flex-col gap-2"}>
                 <h2 className={"text-3xl font-bold lg:text-center"}>Beschikbaarheid</h2>

--- a/src/app/(www)/page.tsx
+++ b/src/app/(www)/page.tsx
@@ -1,37 +1,35 @@
 import Image from "next/image";
 
 export default function Index() {
-    return <main className={"w-full min-h-[100svh]"}>
-        <figure className={"container mx-auto pt-5 flex flex-row justify-center"}>
-            <Image className={"lg:w-1/3"} src={"/images/tenboomgaerde.jpg"} alt={""} width={395} height={255}/>
-        </figure>
-        <section className={"container mx-auto p-2 grid grid-cols-1 md:grid-cols-3 gap-3"}>
-            <div className={"flex flex-col col-span-2"}>
-                <h1 className={"text-4xl py-3"}>Ten Boomgaerde</h1>
-                <p className={"text-base/7"}>Ten Boomgaerde is het beweging.net Dienstencentrum van Lichtervelde. Deze
+    return <main className={"w-full min-h-[calc(100svh-72px)]"}>
+        <div className={"container mx-auto grid lg:grid-cols-2 xl:grid-cols-3 gap-4 px-4"}>
+            <div className={"xl:col-span-2 flex flex-col gap-2"}>
+                <h1 className={"text-5xl font-extrabold"}>Ten boomgaarde</h1>
+                <span className={"bg-red-100 border-red-400 border-2 rounded p-2"}>Uit respect voor de nachtrust van de buurtbewoners kunnen er geen feesten met muziekinstallaties plaats vinden na 22u00.</span>
+                <p>Ten Boomgaerde is het beweging.net Dienstencentrum van Lichtervelde. Deze
                     zaal bevat een grote- en kleine zaal. Deze kunnen voor allerhande zaken zoals een clubfeest,
                     geboortereceptie, verjaardagsfeest, vergaderingen en communiefeest worden gereserveerd.</p>
-                <p className={"text-base/7 text-red-700 pt-5"}>Uit respect voor de nachtrust van de buurtbewoners kunnen
-                    er geen feesten met muziekinstallaties plaats vinden na 22u00.</p>
             </div>
-            <div className={"flex flex-col"}>
-                <h2 className={"text-2xl py-4 flex flew-row md:justify-center"}>Beschikbaarheid</h2>
-                <div>Hier komt de agenda of lijst</div>
+            <div className={"h-full aspect-video md:aspect-auto relative"}>
+                <Image className={"object-cover rounded"} src={"/images/tenboomgaerde.jpg"} alt={"Foto van het gebouw"} fill/>
             </div>
-            <div className={"flex flex-col col-span-2"}>
-                <h2 className={"text-2xl pt-10 pb-2"}>Praktische info</h2>
-                <h3 className={"text-xl pb-3"}>Accomodatie</h3>
+            <aside className={"lg:col-start-2 xl:col-start-3 flex flex-col gap-2"}>
+                <h2 className={"text-3xl font-bold lg:text-center"}>Beschikbaarheid</h2>
+                <div className={"bg-gray-200 flex-grow min-h-[calc((100svh-72px-1rem)/2)] rounded p-2"}>React Kalender</div>
+                {/* h-[calc(100svh-72px-1rem)] */}
+            </aside>
+            <section className={"lg:row-start-2 lg:col-span-1 xl:col-span-2 flex flex-col gap-2"}>
+                <h2 className={"text-3xl font-bold"}>Praktische info</h2>
+                <h3 className={"text-xl font-semibold"}>Accomodatie</h3>
                 <ul role={"list"} className={"list-disc pl-5 space-y-1"}>
                     <li>Grote zaal: mogelijkheid om 100 personen aan tafels te plaatsen</li>
                     <li>Kleine zaal: mogelijkheid om 30 personen aan tafels te plaatsen</li>
                     <li>Keuken met voldoende frigo&apos;s en diepvriezer (klein formaat)</li>
                     <li>Sanitair</li>
-                    <li>Parking voor 10 wagens en eveneens op 50m van de Marktplaats met ruime parkeermogelijkheden.
-                    </li>
+                    <li>Parking voor 10 wagens en eveneens op 50m van de Marktplaats met ruime parkeermogelijkheden.</li>
                 </ul>
-                <p className={"text-base/7 py-2"}>Het complex is volledig rookvrij (art.2 §1 van het KB van
-                    15/05/90).</p>
-                <h3 className={"text-xl pt-7 pb-3"}>Voorzieningen</h3>
+                <p className={"font-light"}>Het complex is volledig rookvrij (art.2 §1 van het KB van 15/05/90).</p>
+                <h3 className={"text-xl font-semibold"}>Voorzieningen</h3>
                 <ul role={"list"} className={"list-disc pl-5 space-y-1"}>
                     <li>Internet toegang (free wifi)</li>
                     <li>Keukenmateriaal voorzien op 100 personen</li>
@@ -44,12 +42,12 @@ export default function Index() {
                     <li>Schrijfbord</li>
                     <li>Mobiel podium</li>
                 </ul>
-                <h3 className={"text-xl pt-7 pb-3"}>Bereikbaarheid</h3>
-                <p className={"text-base/7 py-2"}>Het adres van het dienstencentrum is Boomgaardstraat 4a te 8810
+                <h3 className={"text-xl font-semibold"}>Bereikbaarheid</h3>
+                <p>Het adres van het dienstencentrum is Boomgaardstraat 4a te 8810
                     Lichtervelde. Dit is te bereiken via: Afrit 9 van de E403. Richting centrum Lichtervelde volgen.
                     Eénmaal op de Marktplaats aangekomen, rijdt u rechts van het gemeentehuis de Torhoustraat in. Na 20
                     meter opnieuw naar rechts de Boomgaardstraat in. Op 30 meter rechts vindt u zaal Ten Boomgaerde.</p>
-            </div>
-        </section>
+            </section>
+        </div>
     </main>;
 }


### PR DESCRIPTION
De afbeelding was niet "responsive", omdat deze een overflow had op de body voor schermen, kleiner dan de afbeelding's breedte.

Ook waren enkele overbodige TailwindCSS klassen aan normale tekst meegegeven.