### PR TITLE
Splitting the logic for both types of users.

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@ import NavigationSidebar from "@/components/navigation/navigation-sidebar";
 import NavigationSidebarAuthentication from "@/components/authentication/navigation-sidebar-authentication";
 import NavigationSidebarLink from "@/components/navigation/navigation-sidebar-link";
 import {Box, Calendar, Home, PackageOpen, PieChart, Tag, Users} from "lucide-react";
+import AdminRouteProtection from "@/components/authentication/admin-route-protection";
 
 export const dynamic = 'force-dynamic'
 
@@ -11,18 +12,20 @@ interface LayoutProps {
 }
 
 export default async function layout({children}: LayoutProps) {
-    return <div className={"flex flex-col md:flex-row"}>
-        <NavigationSidebar authNode={<NavigationSidebarAuthentication/>}>
-            <NavigationSidebarLink href={"/dashboard"}><Home/><span>Dashboard</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/agenda"}><Calendar/><span>Agenda</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/zalen"}><Box/><span>Zalen</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/producten"}><PackageOpen/><span>Producten</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/producten/categorieen"}><Tag/><span>Categorieën</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/analyses"}><PieChart/><span>Analyses</span></NavigationSidebarLink>
-            <NavigationSidebarLink href={"/dashboard/users"}><Users/><span>Gebruikers</span></NavigationSidebarLink>
-        </NavigationSidebar>
-        <div className={"w-full"}>
-            {children}
+    return <AdminRouteProtection>
+        <div className={"flex flex-col md:flex-row"}>
+            <NavigationSidebar authNode={<NavigationSidebarAuthentication/>}>
+                <NavigationSidebarLink href={"/dashboard"}><Home/><span>Dashboard</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/agenda"}><Calendar/><span>Agenda</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/zalen"}><Box/><span>Zalen</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/producten"}><PackageOpen/><span>Producten</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/producten/categorieen"}><Tag/><span>Categorieën</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/analyses"}><PieChart/><span>Analyses</span></NavigationSidebarLink>
+                <NavigationSidebarLink href={"/dashboard/users"}><Users/><span>Gebruikers</span></NavigationSidebarLink>
+            </NavigationSidebar>
+            <div className={"w-full"}>
+                {children}
+            </div>
         </div>
-    </div>
+    </AdminRouteProtection>
 }

--- a/components/authentication/admin-component-protection.tsx
+++ b/components/authentication/admin-component-protection.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import {createServerComponentClient} from "@supabase/auth-helpers-nextjs";
+import {cookies} from "next/headers";
+
+interface AdminComponentProtectionProps {
+    children: React.ReactNode;
+}
+
+export default async function AdminComponentProtection({children}: AdminComponentProtectionProps) {
+    const supabase = createServerComponentClient({cookies})
+
+    const {data: {user}} = await supabase.auth.getUser()
+    if (!user) return undefined;
+
+    const {data: adminIsLoggedIn} = await supabase.rpc("is_admin", {"user_id": user.id})
+    if (!adminIsLoggedIn) return undefined;
+
+    return <>{children}</>
+}

--- a/components/authentication/admin-route-protection.tsx
+++ b/components/authentication/admin-route-protection.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import {createServerComponentClient} from "@supabase/auth-helpers-nextjs";
+import {cookies} from "next/headers";
+import {redirect} from "next/navigation";
+import {RedirectType} from "next/dist/client/components/redirect";
+
+interface AdminRouteProtectionProps {
+    children: React.ReactNode;
+}
+
+export default async function AdminRouteProtection({children}: AdminRouteProtectionProps) {
+    const supabase = createServerComponentClient({cookies})
+
+    const {data: {user}} = await supabase.auth.getUser()
+    if (!user) return redirect("/");
+
+    const {data: adminIsLoggedIn} = await supabase.rpc("is_admin", {"user_id": user.id})
+    if (!adminIsLoggedIn) return redirect("/login?error=Meld%20je%20aan%20als%20administrator", RedirectType.replace)
+
+    return <>{children}</>
+}

--- a/components/authentication/navigation-header-authentication.tsx
+++ b/components/authentication/navigation-header-authentication.tsx
@@ -3,6 +3,7 @@ import {cookies} from "next/headers";
 import LogoutButton from "@/components/authentication/LogoutButton";
 import NavigationHeaderLink from "@/components/navigation/navigation-header-link";
 import LoginButton from "@/components/authentication/LoginButton";
+import AdminComponentProtection from "@/components/authentication/admin-component-protection";
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +20,7 @@ export default async function NavigationHeaderAuthentication() {
 async function NavigationIsLogedIn() {
     return <div className={"flex flex-row-reverse gap-2"}>
         <LogoutButton/>
-        <NavigationHeaderLink href={"/dashboard"}>Dashboard</NavigationHeaderLink>
+        <AdminComponentProtection><NavigationHeaderLink href={"/dashboard"}>Dashboard</NavigationHeaderLink></AdminComponentProtection>
     </div>
 }
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -80,19 +80,37 @@ export interface Database {
       }
       users: {
         Row: {
+            city: string | null
+            Email: string | null
           firstname: string | null
           id: string
+            is_admin: boolean
           lastname: string | null
+            phone: string | null
+            postcode: string | null
+            street: string | null
         }
         Insert: {
+            city?: string | null
+            Email?: string | null
           firstname?: string | null
           id: string
+            is_admin?: boolean
           lastname?: string | null
+            phone?: string | null
+            postcode?: string | null
+            street?: string | null
         }
         Update: {
+            city?: string | null
+            Email?: string | null
           firstname?: string | null
           id?: string
+            is_admin?: boolean
           lastname?: string | null
+            phone?: string | null
+            postcode?: string | null
+            street?: string | null
         }
         Relationships: [
           {
@@ -108,7 +126,12 @@ export interface Database {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+        is_admin: {
+            Args: {
+                user_id: string
+            }
+            Returns: boolean
+        }
     }
     Enums: {
       [_ in never]: never
@@ -121,6 +144,7 @@ export interface Database {
 
 export type Tables<T extends keyof Database['public']['Tables']> = Database['public']['Tables'][T]['Row']
 export type Enums<T extends keyof Database['public']['Enums']> = Database['public']['Enums'][T]
+export type Functions<T extends keyof Database['public']['Functions']> = Database['public']['Functions'][T]
 // etc.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "P007-TenBoomgaerde",
+  "name": "p007-vzwtenboomgaerdelichtervelde",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Now the admins and normal user have a split set of logic, mostly in the navbar and protected routes on the dashboard.

The routes should be changed to a middleware protect, but for now this is the best option.

TODO: Middleware instead of react components.