### PR TITLE
Feat: Update maintenance message and remove reservation form from the reservate page

### DIFF
--- a/app/(root)/reservate/page.tsx
+++ b/app/(root)/reservate/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata, NextPage } from "next";
 
 import React from "react";
 
-import AddReservationForm from "./form";
+import Alert, { AlertDescription } from "@/components/atoms/Alert";
 
 export const metadata: Metadata = {
     alternates: {
@@ -15,7 +15,13 @@ export const dynamic = "force-dynamic";
 
 const Page: NextPage = () => (
     <main className={"container mx-auto max-w-(--breakpoint-lg) p-2"}>
-        <AddReservationForm />
+        <Alert>
+            <AlertDescription>
+                De website is momenteel in onderhoud. We werken hard om deze
+                tegen 10 augustus weer beschikbaar te maken. Bedankt voor uw
+                geduld!
+            </AlertDescription>
+        </Alert>
     </main>
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -690,13 +690,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-            "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.0",
+                "@eslint/core": "^0.15.1",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -704,9 +704,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-            "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4111,19 +4111,6 @@
             "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
             "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
             "license": "MIT"
-        },
-        "node_modules/@types/eslint": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
         },
         "node_modules/@types/estree": {
             "version": "1.0.6",


### PR DESCRIPTION
This pull request updates the `reservate` page to replace the reservation form with a maintenance alert message. The key changes involve replacing the imported component and modifying the page's main content.

### Component replacement:
* In `app/(root)/reservate/page.tsx`, replaced the import of `AddReservationForm` with `Alert` and `AlertDescription` from the `@/components/atoms/Alert` module. (`[app/(root)/reservate/page.tsxL5-R5](diffhunk://#diff-0b26573aa9ab96ec1b7dfeaa71749b1e9350a20cc4720acfeb3a07c62efc2b26L5-R5)`)

### Page content update:
* Updated the `Page` component to display a maintenance alert message instead of the `AddReservationForm`. The alert informs users that the website is under maintenance and will be available again by August 10th. (`[app/(root)/reservate/page.tsxL18-R24](diffhunk://#diff-0b26573aa9ab96ec1b7dfeaa71749b1e9350a20cc4720acfeb3a07c62efc2b26L18-R24)`)